### PR TITLE
Add @types/fs-extra to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@sp-packages/cspell-dictionary": "^1.0.0",
         "@sp-packages/depkit": "^2.0.0",
         "@sp-packages/lintrc": "^1.0.0",
+        "@types/fs-extra": "^11.0.4",
         "@types/node": "^22.13.10",
         "@vitest/coverage-v8": "^3.0.8",
         "codecov": "^3.8.3",
@@ -3159,12 +3160,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/fs-extra": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/jsonfile": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/katex": {
       "version": "0.16.7",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@sp-packages/cspell-dictionary": "^1.0.0",
     "@sp-packages/depkit": "^2.0.0",
     "@sp-packages/lintrc": "^1.0.0",
+    "@types/fs-extra": "^11.0.4",
     "@types/node": "^22.13.10",
     "@vitest/coverage-v8": "^3.0.8",
     "codecov": "^3.8.3",


### PR DESCRIPTION
Include the type definitions for fs-extra to improve TypeScript support in the project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated development tooling to enhance type safety and streamline the development process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->