### PR TITLE
Add function to retrieve database port and update labeler permissions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,9 +3,11 @@ name: 'Pull Request Labeler'
 on:
   - pull_request_target
 
+permissions:
+  issues: write
+  contents: write
+  pull-requests: write
+
 jobs:
   labeler:
     uses: SP-Packages/actions/.github/workflows/pr-labeler.yml@v1.1.3
-    permissions:
-      contents: read
-      pull-requests: write

--- a/src/bin/lando-pull.ts
+++ b/src/bin/lando-pull.ts
@@ -54,7 +54,7 @@ program
 
     let config: PullConfig;
     try {
-      config = await readConfig(options.config);
+      config = await readConfig(options);
 
       if (options.authMethod) {
         if (!['password', 'key'].includes(options.authMethod)) {

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -98,6 +98,7 @@ export interface PullConfig {
  * @param quiet - Suppress all non-error output when true
  */
 export interface PullOptions {
+  config?: string;
   debug?: boolean;
   skipDb?: boolean;
   skipFiles?: boolean;


### PR DESCRIPTION
Implement a function to extract the database port from Lando info and update permissions for the pull request labeler workflow to allow writing to issues and contents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatically detects and fills in the database port from the Lando environment if not specified in the configuration.

- **Chores**
  - Updated workflow permissions for GitHub Actions to support broader write access for issues, contents, and pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->